### PR TITLE
Mailto link on email in footer - basic

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -160,7 +160,7 @@
             <ul class="fa-ul">
             <li>
                 <abbr title="Email"><i class="fa fa-li fa-envelope"></i></abbr>
-                info@zlepsujemeskolstvo.sk
+                <a href="mailto:info@zlepsujemeskolstvo.sk">info@zlepsujemeskolstvo.sk</a>
             </li>
             <li>
                 <abbr title="Github"><i class="fa fa-li fa-github"></i></abbr>


### PR DESCRIPTION
Resolving issue #14 with basic mail to link without JS masking. 